### PR TITLE
Update the USU join link

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
               <div class="col form-group">
                 <label for="access">
                   USU membership number <span class="required-mark">*</span>
-                  <a href="https://usu.edu.au/join"><img src="static/help_outline.svg" alt="What is this?"/></a>
+                  <a href="https://usu.edu.au/Membership.aspx"><img src="static/help_outline.svg" alt="What is this?"/></a>
                 </label>
                 <input
                   id="access"


### PR DESCRIPTION
The old USU link now goes to a 404. I think they changed it when general
membership became free. I'm not sure the page I found is quite equivalent to
whatever we linked to before, but just from navigating their site it seems to
be where they want you to go to join.